### PR TITLE
Use Modern gamepad layout with default controller

### DIFF
--- a/game.libretro.tyrquake/resources/buttonmap.xml
+++ b/game.libretro.tyrquake/resources/buttonmap.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-  <controller id="game.controller.default" type="RETRO_DEVICE_JOYPAD">
-    <!-- Look up -->
+  <controller id="game.controller.default" type="RETRO_DEVICE_ANALOG" subclass="2">
+    <!-- Strafe Left -->
     <feature name="y" mapto="RETRO_DEVICE_ID_JOYPAD_X"/>
-    <!-- Look down -->
+    <!-- Swim Down -->
     <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
-    <!-- Look right -->
+    <!-- Strafe Right -->
     <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
-    <!-- Look left -->
+    <!-- Swim Up -->
     <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>
     <!-- D-Pad Up -->
     <feature name="up" mapto="RETRO_DEVICE_ID_JOYPAD_UP"/>
@@ -31,8 +31,12 @@
     <feature name="rightthumb" mapto="RETRO_DEVICE_ID_JOYPAD_R3"/>
     <!-- Menu -->
     <feature name="start" mapto="RETRO_DEVICE_ID_JOYPAD_START"/>
-    <!-- Toggle console -->
+    <!-- Show Scores -->
     <feature name="back" mapto="RETRO_DEVICE_ID_JOYPAD_SELECT"/>
+    <!-- Left Analog stick -->
+    <feature name="leftstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
+    <!-- Right Analog stick -->
+    <feature name="rightstick" mapto="RETRO_DEVICE_INDEX_ANALOG_RIGHT"/>
   </controller>
   <controller id="game.controller.mouse" type="RETRO_DEVICE_MOUSE">
     <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>


### PR DESCRIPTION
The default Kodi controller is based on the xbox 360 and has analog sticks support,
so it makes more sense for it to use the modern gamepad layout supported by this
core, rather than the classic layout that does not make use of the analogs.

This is analogous to the PR I made to the PrBoom Libretro Addon: https://github.com/kodi-game/game.libretro.prboom/pull/8
It's even more necessary here in quake than in Doom, since Quake actually does support freelook.

Tyrquake libretro port similarly uses class 2 for modern layout:
https://github.com/libretro/tyrquake/blob/master/common/libretro.c#L73

    #define RETROPAD_CLASSIC RETRO_DEVICE_JOYPAD
    #define RETROPAD_MODERN RETRO_DEVICE_SUBCLASS(RETRO_DEVICE_ANALOG, 2)